### PR TITLE
Adding LabelEvent reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # label-edit-notifier
 
-> A GitHub App built with [Probot](https://github.com/probot/probot) to listen for edited labels in a repository and notifies via Issue.
+> A GitHub App built with [Probot](https://github.com/probot/probot) to listen for a [LabelEvent](https://developer.github.com/v3/activity/events/types/#labelevent) in a repository and notifies via Issue.
 
 ## Setup
 


### PR DESCRIPTION
Let's add a reference directly to the [LabelEvent](https://developer.github.com/v3/activity/events/types/#labelevent) in the README.